### PR TITLE
Added correct filenames for false_CDR3AA_from_psl.pl command

### DIFF
--- a/MixcrFilter.sh
+++ b/MixcrFilter.sh
@@ -60,7 +60,7 @@ do
 	
 	echo "[`date`] Align CDR3-containing reads of $pfx against human reference genome"
 	blat $ref $pfx.$chain.alignedreads.fa -ooc=$blat11ooc $pfx.$chain.alignedreads.psl
-	./false_CDR3AA_from_psl.pl $pfx.$chain.blat.clones.txt $pfx.$chain.falseCDR3AA \
+	./false_CDR3AA_from_psl.pl $pfx.$chain.alignments.txt $pfx.$chain.alignedreads.psl $chain \
 		> $pfx.$chain.falseCDR3AA
 	./false_CDR3AA_remover.pl $pfx.$chain.blat.clones.txt $pfx.$chain.falseCDR3AA \
 		> $pfx.$chain.blat1.clones.txt


### PR DESCRIPTION
The files given as inputs for `false_CDR3AA_from_psl.pl` are exactly the same as the input files for `false_CDR3AA_remover.pl`, causing `false_CDR3AA_from_psl.pl` to fail with output:

`Usage:$0 <*.alignments.txt> <blat_output.psl (against hg19/hg38)> <gene(TRA|TRB|TRG|TRD)>`

This update replaces the filenames with those specified by the Usage output, fixing this issue.